### PR TITLE
Return empty set, not None when no match found

### DIFF
--- a/pynamematcher/matcher.py
+++ b/pynamematcher/matcher.py
@@ -85,7 +85,4 @@ class PyNameMatcher(object):
             if remove_match and name in names:
                 names.remove(name)
 
-        if len(names) < 1:
-            return None
-
         return names


### PR DESCRIPTION
closes #1 

This will break anyone's code that does `if my_matcher.match("name") is None`
but it won't affect `if my_matcher.match("name") is None`.

Therefore, this probably would need to go through major version bump, or some other way to warn users. Could add in a `warnings.warn` if the function finds no matches.