### PR TITLE
Bugfix: self.lookup is modified sometimes

### DIFF
--- a/pynamematcher/matcher.py
+++ b/pynamematcher/matcher.py
@@ -3,7 +3,6 @@ import os
 import collections
 import csv
 import operator
-import functools
 import warnings
 
 from metaphone import doublemetaphone
@@ -57,7 +56,9 @@ class PyNameMatcher(object):
             use_metaphone = self.use_metaphone
 
         try:
-            names = functools.reduce(operator.or_, self.lookup[name])
+            names = set()
+            for group in self.lookup[name]:
+                names.update(group)
             if name in names:
                 names.remove(name)
         except TypeError:


### PR DESCRIPTION
If a name has only one match group, then functools reduce returns a
pointer to the original set in self.lookup. We really want a copy,
because we immediate do `names.remove(name)`

example:

```python
import pynamematcher as pm
pnm = pm.PyNameMatcher(use_metaphone=False)
print(pnm.lookup["stu"])
pnm.match("stu")
print(pnm.lookup["stu"])
```

yields

```
[{'stuart', 'stu'}]
[{'stuart'}]
```

While I'm at it get rid of the functools stuff, this is much clearer I think.